### PR TITLE
Fix response filtering

### DIFF
--- a/src/com/zoho/crm/library/api/handler/EntityAPIHandler.php
+++ b/src/com/zoho/crm/library/api/handler/EntityAPIHandler.php
@@ -263,7 +263,7 @@ class EntityAPIHandler extends APIHandler
 		{
 			$recordJSON["Tax"]=self::getTaxListAsJSON();
 		}
-		return array_filter($recordJSON);
+		return array_filter($recordJSON, function($v){ return $v !== null; });
 	}
 	
 	public function getTaxListAsJSON()


### PR DESCRIPTION
array_filter() filters out everything equals to `false`, not surprisingly `false` values in arrays. But we do want to keep `false` since checkbox values are boolean and you we need to send `false` value to uncheck. So we only need to filter out `null` values, hence the callback.